### PR TITLE
feat: switch web search to searx

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ DARKBO automatically enhances responses using external tools:
 
 ### Available Tools
 - **DateTime Tool**: Current date, time, and timezone information
-- **Web Search Tool**: DuckDuckGo search integration
+- **Web Search Tool**: Searx search integration
 - **Extensible Framework**: Easy to add new tools
 
 ### Tool Usage Examples

--- a/tools/web_search_tool.py
+++ b/tools/web_search_tool.py
@@ -1,6 +1,6 @@
 """
 Web Search Tool for DARKBO
-Provides web search capabilities using DuckDuckGo search
+Provides web search capabilities using the public Searx instance
 """
 
 import time
@@ -14,86 +14,78 @@ from .base import BaseTool, ToolResult
 
 class WebSearchTool(BaseTool):
     """Tool for performing web searches"""
-    
+
     def __init__(self):
         super().__init__(
             name="web_search",
-            description="Search the web for current information using DuckDuckGo",
+            description="Search the web for current information using Searx",
             version="1.0.0"
         )
-        self.base_url = "https://api.duckduckgo.com/"
-    
-    async def execute(self, 
+        self.base_url = "https://searx.be/search"
+
+    async def execute(self,
                      query: str,
                      max_results: Optional[int] = 5,
                      safe_search: Optional[str] = "moderate",
                      **kwargs) -> ToolResult:
-        """
-        Execute the web search tool
-        
-        Args:
-            query: Search query string
-            max_results: Maximum number of results to return (default: 5)
-            safe_search: Safe search setting - "strict", "moderate", or "off" (default: "moderate")
-            **kwargs: Additional parameters (ignored)
-        
-        Returns:
-            ToolResult with search results
-        """
+        """Execute the web search tool"""
         start_time = time.time()
-        
+
         if not query or not query.strip():
             return ToolResult(
                 success=False,
                 error="Search query cannot be empty",
                 execution_time=time.time() - start_time
             )
-        
+
         try:
-            # Use DuckDuckGo Instant Answer API
-            # This is a simple implementation - in production you might want to use a proper search API
-            search_results = await self._search_duckduckgo(query, max_results, safe_search)
-            
+            search_results = await self._search_searx(query, max_results, safe_search)
+
             result_data = {
                 "query": query,
                 "results": search_results,
                 "total_results": len(search_results),
                 "max_results_requested": max_results,
                 "safe_search": safe_search,
-                "search_engine": "DuckDuckGo"
+                "search_engine": "Searx"
             }
-            
+
             return ToolResult(
                 success=True,
                 data=result_data,
                 execution_time=time.time() - start_time
             )
-            
+
         except Exception as e:
             return ToolResult(
                 success=False,
                 error=f"Web search error: {str(e)}",
                 execution_time=time.time() - start_time
             )
-    
-    async def _search_duckduckgo(self, query: str, max_results: int, safe_search: str) -> List[Dict[str, Any]]:
+
+    async def _search_searx(self, query: str, max_results: int, safe_search: str) -> List[Dict[str, Any]]:
         """
-        Perform search using DuckDuckGo Instant Answer API
-        
+        Perform search using a public Searx instance.
+
         Note: This is a simplified implementation. For production use, consider:
         - Using official search APIs (Google Custom Search, Bing Search API)
         - Implementing proper rate limiting
         - Adding caching mechanisms
         - Better error handling and retries
         """
-        
+
         try:
-            # DuckDuckGo Instant Answer API
+            safesearch_map = {
+                "off": 0,
+                "moderate": 1,
+                "strict": 2,
+            }
+
             params = {
-                'q': query,
-                'format': 'json',
-                'no_html': '1',
-                'skip_disambig': '1'
+                "q": query,
+                "format": "json",
+                "language": "en",
+                "safesearch": safesearch_map.get(safe_search.lower(), 1),
             }
 
             headers = {
@@ -104,10 +96,8 @@ class WebSearchTool(BaseTool):
                 )
             }
 
-            # Make the request in a separate thread to avoid blocking
             loop = asyncio.get_event_loop()
             response = None
-            # Handle transient 202 responses with retries
             for attempt in range(3):
                 response = await loop.run_in_executor(
                     None,
@@ -124,7 +114,6 @@ class WebSearchTool(BaseTool):
                 if response.status_code == 202:
                     await asyncio.sleep(1 + attempt)
                     continue
-                # Non-retryable status
                 return [{
                     "title": "Search Error",
                     "snippet": f"Search service returned status code {response.status_code}",
@@ -139,59 +128,46 @@ class WebSearchTool(BaseTool):
                     "url": "",
                     "source": "error",
                 }]
-            
+
             data = response.json()
             results = []
-            
-            # Extract instant answer if available
-            if data.get('Abstract'):
+
+            for item in data.get("results", []):
                 results.append({
-                    "title": data.get('Heading', 'Instant Answer'),
-                    "snippet": data.get('Abstract'),
-                    "url": data.get('AbstractURL', ''),
-                    "source": data.get('AbstractSource', 'DuckDuckGo')
+                    "title": item.get("title", ""),
+                    "snippet": item.get("content", ""),
+                    "url": item.get("url", ""),
+                    "source": ", ".join(item.get("engines", [])) or "searx",
                 })
-            
-            # Extract related topics
-            for topic in data.get('RelatedTopics', []):
-                if isinstance(topic, dict) and topic.get('Text'):
-                    results.append({
-                        "title": topic.get('Text', '').split(' - ')[0] if ' - ' in topic.get('Text', '') else topic.get('Text', ''),
-                        "snippet": topic.get('Text', ''),
-                        "url": topic.get('FirstURL', ''),
-                        "source": "DuckDuckGo Related"
-                    })
-                
+
                 if len(results) >= max_results:
                     break
-            
-            # If we don't have enough results, add a fallback search suggestion
+
             if len(results) == 0:
                 results.append({
                     "title": f"Search for: {query}",
-                    "snippet": f"No instant answers found. Try searching for '{query}' on a search engine for more detailed results.",
-                    "url": f"https://duckduckgo.com/?q={quote_plus(query)}",
-                    "source": "DuckDuckGo Search Link"
+                    "snippet": f"No results found. Try searching for '{query}' on a search engine for more detailed results.",
+                    "url": f"https://searx.be/search?q={quote_plus(query)}",
+                    "source": "Searx Search Link",
                 })
-            
+
             return results[:max_results]
-            
-        except requests.exceptions.RequestException as e:
-            # Return a helpful error message as a search result
+
+        except requests.exceptions.RequestException:
             return [{
-                "title": "Search Service Unavailable", 
+                "title": "Search Service Unavailable",
                 "snippet": f"Web search is currently unavailable due to network restrictions. For information about '{query}', please check your local knowledge base or contact support directly.",
                 "url": "",
-                "source": "error"
+                "source": "error",
             }]
         except Exception as e:
             return [{
                 "title": "Search Error",
                 "snippet": f"An error occurred while searching: {str(e)}",
                 "url": "",
-                "source": "error"
+                "source": "error",
             }]
-    
+
     def get_parameters_schema(self) -> Dict[str, Any]:
         """Get the JSON schema for web search tool parameters"""
         return {
@@ -214,9 +190,10 @@ class WebSearchTool(BaseTool):
                     "type": "string",
                     "description": "Safe search setting",
                     "enum": ["strict", "moderate", "off"],
-                    "default": "moderate"
+                    "default": "moderate",
                 }
             },
             "required": ["query"],
             "additionalProperties": False
         }
+


### PR DESCRIPTION
## Summary
- replace DuckDuckGo integration with public Searx-based search tool
- document new Searx web search in README

## Testing
- `pytest -q`
- `python -m py_compile tools/web_search_tool.py`


------
https://chatgpt.com/codex/tasks/task_e_689bb5548dd0832d89c8659a37684019